### PR TITLE
Add default title to the resource view

### DIFF
--- a/ckanext/charts/plugin.py
+++ b/ckanext/charts/plugin.py
@@ -58,6 +58,7 @@ class ChartsViewPlugin(p.SingletonPlugin):
         return {
             "name": "charts_view",
             "title": tk._("Chart"),
+            "default_title": tk._("Chart"),
             "schema": settings_schema(),
             "icon": "chart-line",
             "iframed": False,
@@ -216,6 +217,7 @@ class ChartsBuilderViewPlugin(p.SingletonPlugin):
         return {
             "name": "charts_builder_view",
             "title": tk._("Chart Builder"),
+            "default_title": tk._("Chart Builder"),
             "schema": {},
             "icon": "chart-area",
             "iframed": False,


### PR DESCRIPTION
- Adds default title to the resource view so when `charts_view` or `charts_builder_view` are in the `ckan.views.default_views ` it gets more meaningful title than "view" when the view is created automatically.