### PR TITLE
fix: preserve resource view type on submit

### DIFF
--- a/ckanext/charts/templates/package/snippets/view_form.html
+++ b/ckanext/charts/templates/package/snippets/view_form.html
@@ -4,6 +4,7 @@
 {% set errors = errors or {} %}
 
 {{ form.errors(error_summary) }}
+{{ form.hidden('view_type', value=resource_view.view_type) }}
 
 {% if data.view_type in ["charts_view", "charts_builder_view"] %}
     {% include form_template %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 ]
 license = {text = "AGPL"}
 requires-python = ">=3.11"
-version = "1.10.4"
+version = "1.10.5"
 
 [project.optional-dependencies]
 pyarrow = ["pyarrow>=16.0.0,<17.0.0"]


### PR DESCRIPTION
CKAN 2.11.5 changed resource view creation to rely on `view_type` from the submitted form body instead of the query string.

`ckanext-charts` overrides the core `package/snippets/view_form.html` template, so it did not inherit the new hidden `view_type` field added in CKAN core. As a result, creating new resource views on CKAN 2.11.5 could return `404 View Type Not found`.

This adds the hidden `view_type` field to the charts override template, while keeping compatibility with CKAN 2.11.4 and earlier.