### PR TITLE
Errors occurred while rendering the DataStore-backed chart views.

### DIFF
--- a/ckanext/charts/fetchers.py
+++ b/ckanext/charts/fetchers.py
@@ -151,7 +151,11 @@ class DatastoreDataFetcher(DataFetcherStrategy):
 
             query = query.limit(limit)
 
-            df = pd.read_sql_query(query, get_read_engine())
+            with get_read_engine().connect() as conn:
+                log.debug("Executing query: %s", query)
+                result = conn.execute(query)
+                df = pd.DataFrame(result.fetchall(), columns=list(result.keys()))
+                log.debug("Query executed successfully, fetched %d rows", len(df))
         except (ProgrammingError, UndefinedTable, NoSuchTableError) as e:
             raise exception.DataFetchError(
                 f"Error fetching data from DataStore: {e}",
@@ -163,9 +167,8 @@ class DatastoreDataFetcher(DataFetcherStrategy):
         # of missing data in subsequent operations.
         df.replace(["N/A", "NA"], np.nan, inplace=True)
 
-        # Apply numeric conversion to all columns - it will safely ignore
-        # non-numeric values
-        df = df.apply(pd.to_numeric, errors="ignore")
+        # Apply numeric conversion to all columns - leave non-numeric columns unchanged
+        df = df.apply(lambda col: pd.to_numeric(col, errors="coerce") if col.dtype == object else col)
 
         if config.is_cache_enabled():
             self.cache.set_data(

--- a/ckanext/charts/fetchers.py
+++ b/ckanext/charts/fetchers.py
@@ -152,10 +152,8 @@ class DatastoreDataFetcher(DataFetcherStrategy):
             query = query.limit(limit)
 
             with get_read_engine().connect() as conn:
-                log.debug("Executing query: %s", query)
                 result = conn.execute(query)
                 df = pd.DataFrame(result.fetchall(), columns=list(result.keys()))
-                log.debug("Query executed successfully, fetched %d rows", len(df))
         except (ProgrammingError, UndefinedTable, NoSuchTableError) as e:
             raise exception.DataFetchError(
                 f"Error fetching data from DataStore: {e}",
@@ -168,7 +166,7 @@ class DatastoreDataFetcher(DataFetcherStrategy):
         df.replace(["N/A", "NA"], np.nan, inplace=True)
 
         # Apply numeric conversion to all columns - leave non-numeric columns unchanged
-        df = df.apply(lambda col: pd.to_numeric(col, errors="coerce") if col.dtype == object else col)
+        df = df.apply(self._to_numeric_safe)
 
         if config.is_cache_enabled():
             self.cache.set_data(
@@ -181,6 +179,12 @@ class DatastoreDataFetcher(DataFetcherStrategy):
             )
 
         return df
+
+    def _to_numeric_safe(self, col: pd.Series) -> pd.Series:
+        try:
+            return pd.to_numeric(col)
+        except (ValueError, TypeError):
+            return col
 
     def _settings_changed(self, cached_settings: dict[str, Any] | None) -> bool:
         """Checks if relevant settings have changed compared to the cached version.

--- a/ckanext/charts/tests/test_fetchers.py
+++ b/ckanext/charts/tests/test_fetchers.py
@@ -197,3 +197,26 @@ class TestFileSystemDataFetcher:
 
         with pytest.raises(DataFetchError):
             fetcher.fetch_data()
+
+
+class TestNumericConversion:
+    def test_to_numeric_safe_preserves_text_columns(self):
+        """Ensure numeric strings are converted while text columns stay unchanged.
+
+        This covers the previous behavior of pd.to_numeric(errors="ignore"):
+        non-numeric object columns must not be coerced to NaN.
+        """
+        df = pd.DataFrame(
+            {
+                "label": ["Alice", "Bob"],
+                "value": ["10", "20"],
+            },
+        )
+
+        fetcher = fetchers.DatastoreDataFetcher("dummy_resource_id")
+        result = df.apply(fetcher._to_numeric_safe)
+
+        assert result["label"].tolist() == ["Alice", "Bob"]
+        assert result["label"].notna().all()
+        assert result["value"].tolist() == [10, 20]
+        assert pd.api.types.is_numeric_dtype(result["value"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 ]
 license = {text = "AGPL"}
 requires-python = ">=3.11"
-version = "1.10.5"
+version = "1.10.6"
 
 [project.optional-dependencies]
 pyarrow = ["pyarrow>=16.0.0,<17.0.0"]


### PR DESCRIPTION
Problem

Two errors occurred when rendering chart views backed by the DataStore (chart, chart builder):

1. [TypeError: Query must be a string unless using sqlalchemy.](vscode-file://vscode-app/snap/code/241/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — pandas' read_sql_query failed to recognize CKAN's wrapped SQLAlchemy engine as a proper SQLAlchemy connection, falling back to a DBAPI path that requires plain SQL strings.

2. [ValueError: invalid error value specified](vscode-file://vscode-app/snap/code/241/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — [pd.to_numeric(..., errors="ignore")](vscode-file://vscode-app/snap/code/241/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was removed in pandas 2.2+.

Changes

[fetchers.py](vscode-file://vscode-app/snap/code/241/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — [fetch_data](vscode-file://vscode-app/snap/code/241/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Replaced [pd.read_sql_query(query, get_read_engine())](vscode-file://vscode-app/snap/code/241/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with a direct SQLAlchemy execution, building the DataFrame from the result set:

```
with get_read_engine().connect() as conn:
    result = conn.execute(query)
    df = pd.DataFrame(result.fetchall(), columns=list(result.keys()))
```
This bypasses pandas' connection-type detection entirely.

`fetchers.py`— `fetch_data`: Replaced the deprecated  `pd.to_numeric, errors="ignore" `with :

`df = df.apply(lambda col: pd.to_numeric(col, errors="coerce") if col.dtype == object else col)`

Only `object` -dtype columns are attempted for conversion; non-numeric values become `NaN` and non-object columns are left untouched.

