### PR TITLE
fix: submit chart preview updates with POST

### DIFF
--- a/ckanext/charts/templates/charts/snippets/charts_form_fields.html
+++ b/ckanext/charts/templates/charts/snippets/charts_form_fields.html
@@ -31,7 +31,7 @@
     </ul>
 
     <div class="tab-content active" id="pills-tabContent"
-        hx-get="{{ h.url_for('charts_view.update_chart', resource_id=resource_id, resource_view_id=resource_view_id) }}" hx-trigger="load, submit, change"
+        hx-post="{{ h.url_for('charts_view.update_chart', resource_id=resource_id, resource_view_id=resource_view_id) }}" hx-trigger="load, submit, change"
         hx-include="closest form" hx-target="#charts-view--preview" hx-indicator="#chart-indicator">
 
         {% for tab in form_tabs %}

--- a/ckanext/charts/views.py
+++ b/ckanext/charts/views.py
@@ -29,7 +29,7 @@ def _check_resource_access(resource_id: str) -> None:
         tk.abort(403, tk._("Not authorized to view this resource"))
 
 
-@charts.route("/api/utils/charts/<resource_id>/update-chart")
+@charts.route("/api/utils/charts/<resource_id>/update-chart", methods=["GET", "POST"])
 def update_chart(  # noqa: PLR0911
     resource_id: str,
 ) -> str:
@@ -42,7 +42,7 @@ def update_chart(  # noqa: PLR0911
     """
     _check_resource_access(resource_id)
 
-    data = parse_params(tk.request.args)
+    data = parse_params(tk.request.values)
 
     resource_view_id = data.get("resource_view_id")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ckanext-charts"
 description = ""
 keywords = ["CKAN", "charts", "visualization"]
 readme = "README.md"
-version = "1.13.0"
+version = "1.13.1"
 authors = [
     {name = "DataShades", email = "datashades@linkdigital.com.au"},
     {name = "Sergey Motornyuk", email = "sergey.motornyuk@linkdigital.com.au"},


### PR DESCRIPTION
Chart preview requests currently send the full form state in the URL via `GET`. With multiple or long filters, the URL can exceed proxy limits and return `502 Bad Gateway`.

This changes chart preview updates to use `POST`, sending the form data in the request body while keeping the endpoint compatible with existing `GET` requests.